### PR TITLE
Add bundler picking with optional CLI argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,6 +83,23 @@ function hasScope(node) {
   }
 }
 
+function hasChosenBundler(argument, bundler) {
+  if (
+    argument.includes('r') && bundler === 'Rollup' ||
+    argument.includes('w') && bundler === 'Webpack' ||
+    argument.includes('e') && bundler === 'ESBuild'
+  ) {
+    return true
+  } else {
+    return false
+  }
+}
+
+// Remove bundlers that are not chosen
+for (const bundler in bundlers) {
+  if(process.argv[3] && !hasChosenBundler(process.argv[3], bundler)) delete bundlers[bundler]
+}
+
 try {
   const input = process.argv[2]
   const file = path.resolve(input)


### PR DESCRIPTION
Hey there, thanks for the tool. In my case, I just needed to test for ESBuild tree shaking, but it seems like running the tool automatically checks all three bundlers.
So I added this simple snippet of code to add a CLI argument in the format `-r` `-w` `-e` or any combination of these to add a bundler picking functionality.